### PR TITLE
fixed gibberish after pressing next on map

### DIFF
--- a/js/mapscript.js
+++ b/js/mapscript.js
@@ -114,10 +114,13 @@ if(hasPlayed){
 }
 
 function writeDialogue(text){
-   if(i < text.length){
-      dialogue.textContent += text.charAt(i);
-      i++;
-      setTimeout(writeDialogue, speed, text);
+  document.getElementById("map-continue").disabled = true;
+  if(i < text.length){
+    dialogue.textContent += text.charAt(i);
+    i++;
+    setTimeout(writeDialogue, speed, text);
+  } else {
+    document.getElementById("map-continue").disabled = false;
   }
   
 }


### PR DESCRIPTION
basically I disabled the next button on the map, only re-enabling it when text is done rendering